### PR TITLE
Fix HTTP Server Startup (Issue #6)

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,12 +1,15 @@
-import { HttpApiBuilder, HttpMiddleware } from "@effect/platform"
+import { HttpApiBuilder, HttpMiddleware, HttpServer } from "@effect/platform"
 import { NodeHttpServer, NodeRuntime } from "@effect/platform-node"
 import { Layer } from "effect"
 import { createServer } from "node:http"
 import { ApiLive } from "./Api.js"
 
+const port = 3000
+
 const HttpLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
   Layer.provide(ApiLive),
-  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
+  HttpServer.withLogAddress,
+  Layer.provide(NodeHttpServer.layer(createServer, { port }))
 )
 
 Layer.launch(HttpLive).pipe(NodeRuntime.runMain)


### PR DESCRIPTION
## Changes
Fixed HTTP server startup issue by adding proper startup confirmation logging using Effect's built-in `HttpServer.withLogAddress` middleware.

## Issue
Closes #6

## Testing
- [x] Manual testing completed - server now shows clear startup message
- [x] Health endpoint accessibility confirmed - responds with `{"status":"ok"}`  
- [x] Integration testing performed - no hanging behavior

## Notes  
The issue was not a technical problem but a UX issue - users couldn't tell when the server was ready due to lack of startup logging. Full root cause analysis and solution details documented in Issue #6.