### PR TITLE
test(server): set up testing infrastructure (Task 49)

### DIFF
--- a/apps/server/src/db/DatabaseManagerImpl.ts
+++ b/apps/server/src/db/DatabaseManagerImpl.ts
@@ -4,8 +4,8 @@ import { PgClient } from "@effect/sql-pg"
 import { Config, Context, Effect, Layer, Option } from "effect"
 import type { ConfigError } from "effect/ConfigError"
 import type { Redacted } from "effect/Redacted"
-import { DatabaseManager, MissingMerchantDatabaseUrlError } from "./DatabaseManager.js"
 import { types as pgTypes } from "pg"
+import { DatabaseManager, MissingMerchantDatabaseUrlError } from "./DatabaseManager.js"
 
 // Configure pg (node-postgres) type parsers so encoded values match our schemas
 // - 1184 timestamptz: keep ISO string as-is

--- a/apps/server/test/domain/shared/errors/DomainErrors.test.ts
+++ b/apps/server/test/domain/shared/errors/DomainErrors.test.ts
@@ -1,0 +1,65 @@
+import {
+  InsufficientBalance,
+  ProductUnavailable,
+  ServiceUnavailable
+} from "@server/domain/shared/errors/DomainErrors.js"
+import { describe, expect, it } from "vitest"
+
+describe("Domain Error Types", () => {
+  describe("ProductUnavailable", () => {
+    it("creates error with product context", () => {
+      const error = new ProductUnavailable({
+        product_code: "PROD_123",
+        country: "US",
+        reason: "not_found"
+      })
+
+      expect(error.product_code).toBe("PROD_123")
+      expect(error.country).toBe("US")
+      expect(error.reason).toBe("not_found")
+      expect(error.toString()).toContain("PROD_123")
+    })
+
+    it("generates appropriate error messages by reason", () => {
+      const notFound = new ProductUnavailable({
+        product_code: "PROD_123",
+        reason: "not_found"
+      })
+      expect(notFound.toString()).toContain("not found in catalog")
+
+      const archived = new ProductUnavailable({
+        product_code: "PROD_123",
+        reason: "archived"
+      })
+      expect(archived.toString()).toContain("no longer available")
+    })
+  })
+
+  describe("InsufficientBalance", () => {
+    it("creates error with balance context", () => {
+      const error = new InsufficientBalance({
+        user_id: "user-123",
+        current_balance: -5,
+        reason: "negative_balance"
+      })
+
+      expect(error.user_id).toBe("user-123")
+      expect(error.current_balance).toBe(-5)
+      expect(error.toString()).toContain("-5 credits")
+    })
+  })
+
+  describe("ServiceUnavailable", () => {
+    it("creates error with service context and retry info", () => {
+      const error = new ServiceUnavailable({
+        service: "database",
+        reason: "database_connection_failure",
+        retry_after_seconds: 30
+      })
+
+      expect(error.service).toBe("database")
+      expect(error.retry_after_seconds).toBe(30)
+      expect(error.toString()).toContain("Retry after 30 seconds")
+    })
+  })
+})

--- a/apps/server/test/fixtures/database-setup.ts
+++ b/apps/server/test/fixtures/database-setup.ts
@@ -1,0 +1,7 @@
+// Minimal test database setup scaffolding
+// Extend with real connection and migration logic as repository tests are implemented
+export { TEST_DATABASE_URL } from "../utils/database-helpers.js"
+
+export const ensureTestDatabase = async () => {
+  // Implement connection checks / migrations when needed
+}

--- a/apps/server/test/fixtures/merchant-context.ts
+++ b/apps/server/test/fixtures/merchant-context.ts
@@ -1,0 +1,17 @@
+import { MerchantContext } from "@credit-system/shared"
+import type { MerchantContext as MerchantContextType } from "@credit-system/shared"
+import { Layer } from "effect"
+
+// Test MerchantContext implementation
+export class TestMerchantContext implements MerchantContextType {
+  readonly merchantId: string
+  constructor(merchantId = "test-merchant-123") {
+    this.merchantId = merchantId
+  }
+}
+
+// Layer for test dependency injection
+export const TestMerchantContextLive = Layer.succeed(
+  MerchantContext,
+  new TestMerchantContext()
+)

--- a/apps/server/test/fixtures/test-data.ts
+++ b/apps/server/test/fixtures/test-data.ts
@@ -1,0 +1,57 @@
+import { createMonthDate } from "@server/domain/shared/values/MonthDate.js"
+
+// Sample test data organized by business aggregate
+export const TestProducts = {
+  SELLABLE_BASIC: {
+    product_code: "TEST_BASIC",
+    title: "Test Basic Package",
+    credits: 100,
+    access_period_days: 30,
+    distribution: "sellable" as const,
+    grant_policy: null,
+    effective_at: new Date("2025-01-01T00:00:00Z"),
+    archived_at: null,
+    price_rows: null
+  },
+
+  GRANT_WELCOME: {
+    product_code: "TEST_WELCOME",
+    title: "Test Welcome Grant",
+    credits: 50,
+    access_period_days: 30,
+    distribution: "grant" as const,
+    grant_policy: "apply_on_signup" as const,
+    effective_at: new Date("2025-01-01T00:00:00Z"),
+    archived_at: null,
+    price_rows: null
+  }
+} as const
+
+export const TestUsers = {
+  USER_1: "test-user-1",
+  USER_2: "test-user-2"
+} as const
+
+// Helper to create test ledger entries
+export const createTestLedgerEntry = (overrides: Partial<any> = {}) => {
+  const createdAt = new Date("2025-01-15T12:00:00Z")
+  const entryId = "test-entry-" + Math.random().toString(36).substring(7)
+
+  return {
+    entry_id: entryId,
+    user_id: TestUsers.USER_1,
+    lot_id: entryId, // Self-reference for issuance entries
+    lot_month: createMonthDate(createdAt),
+    amount: 100,
+    reason: "purchase",
+    operation_type: "payment_card",
+    resource_amount: 99.99,
+    resource_unit: "USD",
+    workflow_id: "test-workflow",
+    product_code: "TEST_BASIC",
+    expires_at: new Date("2025-02-15T00:00:00Z"),
+    created_at: createdAt,
+    created_month: createMonthDate(createdAt),
+    ...overrides
+  }
+}

--- a/apps/server/test/infrastructure/repositories/README.md
+++ b/apps/server/test/infrastructure/repositories/README.md
@@ -1,0 +1,2 @@
+Repository implementation tests live here. Add tests per repository module.
+

--- a/apps/server/test/utils/database-helpers.ts
+++ b/apps/server/test/utils/database-helpers.ts
@@ -1,0 +1,13 @@
+// Placeholder database testing utilities for repository tests
+// Extend with real helpers (migrations, truncation, seeding) as needed
+
+export const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL || "postgresql://test:test@localhost:5432/credit_test"
+
+export const withIsolatedSchema = async (schemaName: string, run: () => Promise<void>) => {
+  // Implement schema creation / teardown strategy when adding real DB tests
+  await run()
+}
+
+export const truncateTables = async (_tables: Array<string>) => {
+  // Implement truncation when adding real DB tests
+}

--- a/apps/server/test/utils/effect-helpers.ts
+++ b/apps/server/test/utils/effect-helpers.ts
@@ -1,0 +1,31 @@
+import type { Either } from "effect"
+import { Effect } from "effect"
+import { expect } from "vitest"
+
+// Run an Effect and capture Either result synchronously
+export const runTestEffect = <A, E>(effect: Effect.Effect<A, E>): Either.Either<A, E> => {
+  return Effect.runSync(Effect.either(effect)) as Either.Either<A, E>
+}
+
+// Assertion helpers for Effect results
+export const expectRight = <A, E>(result: Either.Either<A, E>): A => {
+  expect((result as any)._tag).toBe("Right")
+  return (result as any).right as A
+}
+
+export const expectLeft = <A, E>(result: Either.Either<A, E>): E => {
+  expect((result as any)._tag).toBe("Left")
+  return (result as any).left as E
+}
+
+// Effect test wrapper that handles common patterns
+export const testEffect = <A, E>(
+  name: string,
+  effect: Effect.Effect<A, E>,
+  assertion: (result: Either.Either<A, E>) => void
+) => {
+  return it(name, () => {
+    const result = runTestEffect(effect)
+    assertion(result)
+  })
+}

--- a/apps/server/tsconfig.test.json
+++ b/apps/server/tsconfig.test.json
@@ -5,7 +5,7 @@
     { "path": "tsconfig.src.json" }
   ],
   "compilerOptions": {
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
     "rootDir": "test",
     "noEmit": true


### PR DESCRIPTION
Closes #49

Summary
- Add test scaffolding under `apps/server/test/` aligned with updated architecture
- Fixtures: test-data, merchant-context, database-setup
- Utils: effect-helpers, database-helpers
- Domain error tests: ProductUnavailable, InsufficientBalance, ServiceUnavailable
- Update tsconfig.test to include `vitest/globals`

Validation
- Lint/format: clean (`pnpm lint`)
- Type-check: clean (`pnpm run check`)
- Tests: passing in @credit-system/server (3 files, 18 tests)

Notes
- Repository tests folder stubbed: `test/infrastructure/repositories/` for upcoming tasks
- `TEST_DATABASE_URL` single-sourced in `test/utils/database-helpers.ts` and re-exported from `fixtures/database-setup.ts`